### PR TITLE
switch to promise version of addIceCandidate to fix running on Firefox / Safari

### DIFF
--- a/lib/src/rtc_peerconnection_impl.dart
+++ b/lib/src/rtc_peerconnection_impl.dart
@@ -227,18 +227,9 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
   }
 
   @override
-  Future<void> addCandidate(RTCIceCandidate candidate) async {
-    try {
-      Completer completer = Completer<void>();
-      var success = js.allowInterop(() => completer.complete());
-      var failure = js.allowInterop((e) => completer.completeError(e));
-      jsutil.callMethod(
-          _jsPc, 'addIceCandidate', [_iceToJs(candidate), success, failure]);
-
-      return completer.future;
-    } catch (e) {
-      print(e.toString());
-    }
+  Future<void> addCandidate(RTCIceCandidate candidate) {
+    return jsutil.promiseToFuture<void>(
+        jsutil.callMethod(_jsPc, 'addIceCandidate', [_iceToJs(candidate)]));
   }
 
   @override


### PR DESCRIPTION
This PR changes the addCandidate implementation to use the promise based version of the corresponding javascript function. Currently the deprecated callback version is used, which works in chrome, but causes issues when running in firefox or safari. In the later cases neither callback seems to be called and the future never completes.

The promised based version has been testen on Chrome/Firefox/Safari and did not cause any issue. As the remaining implementation uses the promise based version of the WebRTC api anyway it would also be more consistent to switch to the promise based version for this function.