### PR TITLE
Fix `connectionState` being incorrect

### DIFF
--- a/lib/src/rtc_peerconnection_impl.dart
+++ b/lib/src/rtc_peerconnection_impl.dart
@@ -94,8 +94,8 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
       onSignalingState?.call(_signalingState!);
     });
 
-    _jsPc.onIceConnectionStateChange.listen((_) {
-      _connectionState = peerConnectionStateForString(_jsPc.iceConnectionState);
+    _jsPc.onConnectionStateChange.listen((_) {
+      _connectionState = peerConnectionStateForString(_jsPc.connectionState);
       onConnectionState?.call(_connectionState!);
     });
 


### PR DESCRIPTION
`connectionState` now relies on lifecyle and values of its javascript peer

Fixes #10