### PR TITLE
Fix #883 in flutter_webrtc

### DIFF
--- a/lib/src/media_recorder.dart
+++ b/lib/src/media_recorder.dart
@@ -19,7 +19,12 @@ class MediaRecorder extends _interface.MediaRecorder {
     MediaStream stream, {
     Function(dynamic blob, bool isLastOne)? onDataChunk,
     String? mimeType,
+    int timeSlice = 1000,
   }) =>
-      _delegate.startWeb(stream,
-          onDataChunk: onDataChunk, mimeType: mimeType ?? 'video/webm');
+      _delegate.startWeb(
+        stream,
+        onDataChunk: onDataChunk,
+        mimeType: mimeType ?? 'video/webm',
+        timeSlice: timeSlice,
+      );
 }

--- a/lib/src/media_recorder_impl.dart
+++ b/lib/src/media_recorder_impl.dart
@@ -25,6 +25,7 @@ class MediaRecorderWeb extends MediaRecorder {
     MediaStream stream, {
     Function(dynamic blob, bool isLastOne)? onDataChunk,
     String mimeType = 'video/webm',
+    int timeSlice = 1000,
   }) {
     var _native = stream as MediaStreamWeb;
     _recorder = html.MediaRecorder(_native.jsStream, {'mimeType': mimeType});
@@ -52,7 +53,7 @@ class MediaRecorderWeb extends MediaRecorder {
         );
       });
     }
-    _recorder.start();
+    _recorder.start(timeSlice);
   }
 
   @override


### PR DESCRIPTION
Issue Mentioned : https://github.com/flutter-webrtc/flutter-webrtc/issues/883

**Changes** - Now there is a timeslice argument in startWeb Function of MediaRecorder, which also resolves the problem of onDataChunk Method not triggering unless we stop the recording.