### PR TITLE
fix type cast exception in getConstraints()

### DIFF
--- a/lib/src/media_stream_track_impl.dart
+++ b/lib/src/media_stream_track_impl.dart
@@ -37,7 +37,9 @@ class MediaStreamTrackWeb extends MediaStreamTrack {
 
   @override
   Map<String, dynamic> getConstraints() {
-    return jsTrack.getConstraints() as Map<String, dynamic>;
+    final c = jsTrack.getConstraints();
+    final jso = (c as JSObject).dartify();
+    return (jso as Map).cast<String, dynamic>();
   }
 
   @override
@@ -47,7 +49,8 @@ class MediaStreamTrackWeb extends MediaStreamTrack {
     final arg = js.jsify(constraints ?? {});
 
     final _val = await js.promiseToFuture<void>(
-        js.callMethod(jsTrack, 'applyConstraints', [arg]));
+      js.callMethod(jsTrack, 'applyConstraints', [arg]),
+    );
     return _val;
   }
 


### PR DESCRIPTION
Hello, while trying to see if I can workaround the apparent volume change on windows 11 chrome when muting and unmuting the local participant, I tried to use the Helper.setVolume() which resulting in this error.
The attached code avoids the exception and I think is doing the right thing, but the whole js_interop stuff is pretty new.



```
ERROR 10:04:07.057:<fn>/735:zi9i-7eh8-zqs1-yfpz/4cpsr-7ockd-b9dk1:TypeError: Instance of 'LegacyJavaScriptObject': type 'LegacyJavaScriptObject' is not a subtype of type 'Map<String, dynamic>'
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 297:3  throw_
dart-sdk/lib/_internal/js_shared/lib/rti.dart 1385:3                         _failedAsCheck
dart-sdk/lib/_internal/js_shared/lib/rti.dart 1363:3                         _generalAsCheckImplementation
packages/dart_webrtc/src/media_stream_track_impl.dart 40:38                  getConstraints
packages/core/bloc/livekit.dart 729:44                                       <fn>
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 45:50           <fn>
dart-sdk/lib/async/zone.dart 1407:47                                         _rootRunUnary
dart-sdk/lib/async/zone.dart 1308:19                                         runUnary
dart-sdk/lib/async/future_impl.dart 162:18                                   handleValue
dart-sdk/lib/async/future_impl.dart 838:44                                   handleValueCallback
dart-sdk/lib/async/future_impl.dart 867:13                                   _propagateToListeners
dart-sdk/lib/async/future_impl.dart 643:5                                    [_completeWithValue]
dart-sdk/lib/async/future_impl.dart 713:7                                    <fn>
dart-sdk/lib/async/zone.dart 1399:13                                         _rootRun
dart-sdk/lib/async/zone.dart 1301:19                                         run
dart-sdk/lib/async/zone.dart 1209:7                                          runGuarded
dart-sdk/lib/async/zone.dart 1249:23                                         callback
dart-sdk/lib/async/schedule_microtask.dart 40:11                             _microtaskLoop
dart-sdk/lib/async/schedule_microtask.dart 49:5                              _startMicrotaskLoop
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 181:7           <fn>
```