### PR TITLE
Fix build error in flutter beta channel caused by "function converted via 'toJS' contains invalid types"

### DIFF
--- a/lib/src/media_stream_track_impl.dart
+++ b/lib/src/media_stream_track_impl.dart
@@ -10,9 +10,21 @@ import 'utils.dart';
 
 class MediaStreamTrackWeb extends MediaStreamTrack {
   MediaStreamTrackWeb(this.jsTrack) {
-    jsTrack.addEventListener('ended', ((event) => onEnded?.call()).toJS);
-    jsTrack.addEventListener('mute', ((event) => onMute?.call()).toJS);
-    jsTrack.addEventListener('unmute', ((event) => onUnMute?.call()).toJS);
+    jsTrack.addEventListener(
+        'ended',
+        (web.Event event) {
+          onEnded?.call();
+        }.toJS);
+    jsTrack.addEventListener(
+        'mute',
+        (web.Event event) {
+          onMute?.call();
+        }.toJS);
+    jsTrack.addEventListener(
+        'unmute',
+        (web.Event event) {
+          onUnMute?.call();
+        }.toJS);
   }
 
   final web.MediaStreamTrack jsTrack;

--- a/lib/src/rtc_data_channel_impl.dart
+++ b/lib/src/rtc_data_channel_impl.dart
@@ -11,7 +11,7 @@ class RTCDataChannelWeb extends RTCDataChannel {
     messageStream = _messageController.stream;
     _jsDc.addEventListener(
         'close',
-        (_) {
+        (web.Event _) {
           _state = RTCDataChannelState.RTCDataChannelClosed;
           _stateChangeController.add(_state);
           onDataChannelState?.call(_state);
@@ -19,7 +19,7 @@ class RTCDataChannelWeb extends RTCDataChannel {
         false.toJS);
     _jsDc.addEventListener(
         'open',
-        (_) {
+        (web.Event _) {
           _state = RTCDataChannelState.RTCDataChannelOpen;
           _stateChangeController.add(_state);
           onDataChannelState?.call(_state);
@@ -27,15 +27,16 @@ class RTCDataChannelWeb extends RTCDataChannel {
         false.toJS);
     _jsDc.addEventListener(
         'message',
-        (web.MessageEvent event) async {
-          var msg = await _parse(event.data);
-          _messageController.add(msg);
-          onMessage?.call(msg);
+        (web.MessageEvent event) {
+          _parse(event.data).then((msg) {
+            _messageController.add(msg);
+            onMessage?.call(msg);
+          });
         }.toJS,
         false.toJS);
     _jsDc.addEventListener(
         'bufferedamountlow',
-        (_) {
+        (web.Event _) {
           onBufferedAmountLow?.call(bufferedAmount ?? 0);
         }.toJS,
         false.toJS);

--- a/lib/src/rtc_peerconnection_impl.dart
+++ b/lib/src/rtc_peerconnection_impl.dart
@@ -27,7 +27,7 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
   RTCPeerConnectionWeb(this._peerConnectionId, this._jsPc) {
     _jsPc.addEventListener(
         'datachannel',
-        (dataChannelEvent) {
+        (web.RTCDataChannelEvent dataChannelEvent) {
           if (dataChannelEvent.channel != null) {
             onDataChannel?.call(RTCDataChannelWeb(dataChannelEvent.channel!));
           }
@@ -35,7 +35,7 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
 
     _jsPc.addEventListener(
         'icecandidate',
-        (iceEvent) {
+        (web.RTCPeerConnectionIceEvent iceEvent) {
           if (iceEvent.candidate != null) {
             onIceCandidate?.call(_iceFromJs(iceEvent.candidate!));
           }
@@ -43,7 +43,7 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
 
     _jsPc.addEventListener(
         'iceconnectionstatechange',
-        (_) {
+        (web.Event _) {
           _iceConnectionState =
               iceConnectionStateForString(_jsPc.iceConnectionState);
           onIceConnectionState?.call(_iceConnectionState!);
@@ -88,7 +88,7 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
 
     _jsPc.addEventListener(
         'signalingstatechange',
-        (_) {
+        (web.Event _) {
           _signalingState = signalingStateForString(_jsPc.signalingState);
           onSignalingState?.call(_signalingState!);
         }.toJS);
@@ -96,7 +96,7 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
     if (!browser.isFirefox) {
       _jsPc.addEventListener(
           'connectionstatechange',
-          (_) {
+          (web.Event _) {
             _connectionState =
                 peerConnectionStateForString(_jsPc.connectionState);
             onConnectionState?.call(_connectionState!);
@@ -105,7 +105,7 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
 
     _jsPc.addEventListener(
         'negotiationneeded',
-        (_) {
+        (web.Event _) {
           onRenegotiationNeeded?.call();
         }.toJS);
 


### PR DESCRIPTION
The latest beta channel does not support without type annotations like
```
        (event) {
          _durationCompleter?.completeError(_audioElement.error!);
        }.toJS);
```
It raises error with 
```
Error: Function converted via 'toJS' contains invalid types in its function signature: 'Null Function(*dynamic*)'.
        }.toJS);
```
Added event type for them.

same issue: https://github.com/ryanheise/just_audio/issues/1326