### PR TITLE
fix: don't try to access optional track settings

### DIFF
--- a/lib/src/media_stream_track_impl.dart
+++ b/lib/src/media_stream_track_impl.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
-import 'dart:js_util' as js;
 import 'dart:typed_data';
 
 import 'package:web/web.dart' as web;

--- a/lib/src/media_stream_track_impl.dart
+++ b/lib/src/media_stream_track_impl.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'dart:js_util' as js;
 import 'dart:typed_data';
 
 import 'package:web/web.dart' as web;
@@ -77,25 +79,49 @@ class MediaStreamTrackWeb extends MediaStreamTrack {
     var settings = jsTrack.getSettings();
     var _converted = <String, dynamic>{};
     if (kind == 'audio') {
-      _converted['sampleRate'] = settings.sampleRate;
-      _converted['sampleSize'] = settings.sampleSize;
-      _converted['echoCancellation'] = settings.echoCancellation;
-      _converted['autoGainControl'] = settings.autoGainControl;
-      _converted['noiseSuppression'] = settings.noiseSuppression;
-      _converted['latency'] = settings.latency;
-      _converted['channelCount'] = settings.channelCount;
+      if (settings.has('sampleRate')) {
+        _converted['sampleRate'] = settings.sampleRate;
+      }
+      if (settings.has('sampleSize')) {
+        _converted['sampleSize'] = settings.sampleSize;
+      }
+      if (settings.has('echoCancellation')) {
+        _converted['echoCancellation'] = settings.echoCancellation;
+      }
+      if (settings.has('autoGainControl')) {
+        _converted['autoGainControl'] = settings.autoGainControl;
+      }
+      if (settings.has('noiseSuppression')) {
+        _converted['noiseSuppression'] = settings.noiseSuppression;
+      }
+      if (settings.has('latency')) _converted['latency'] = settings.latency;
+      if (settings.has('channelCount')) {
+        _converted['channelCount'] = settings.channelCount;
+      }
     } else {
-      _converted['width'] = settings.width;
-      _converted['height'] = settings.height;
-      _converted['aspectRatio'] = settings.aspectRatio;
-      _converted['frameRate'] = settings.frameRate;
-      if (isMobile) {
+      if (settings.has('width')) {
+        _converted['width'] = settings.width;
+      }
+      if (settings.has('height')) {
+        _converted['height'] = settings.height;
+      }
+      if (settings.has('aspectRatio')) {
+        _converted['aspectRatio'] = settings.aspectRatio;
+      }
+      if (settings.has('frameRate')) {
+        _converted['frameRate'] = settings.frameRate;
+      }
+      if (isMobile && settings.has('facingMode')) {
         _converted['facingMode'] = settings.facingMode;
       }
-      _converted['resizeMode'] = settings.resizeMode;
+      if (settings.has('resizeMode')) {
+        _converted['resizeMode'] = settings.resizeMode;
+      }
     }
-    _converted['deviceId'] = settings.deviceId;
-    _converted['groupId'] = settings.groupId;
+    if (settings.has('deviceId')) _converted['deviceId'] = settings.deviceId;
+    if (settings.has('groupId')) {
+      _converted['groupId'] = settings.groupId;
+    }
     return _converted;
   }
 


### PR DESCRIPTION
Some properties defined in `package:web/web.dart` are defined as non-nullable, while some browsers don't support them. In my case, `aspectRatio` is not defined for [Firefox](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings/aspectRatio#browser_compatibility), causing a failed non-null check

This seems to be a problem with the IDL itself being inconsistent (see https://github.com/dart-lang/web/issues/309).

Checking availability before accessing the fields seems to be an endorsed method: https://github.com/dart-lang/web/issues/181#issuecomment-1955207827

I tried to refactor the code to use `settings.has(property)` and `settings[propery]` in a loop, but then we lose type conversion and our map only contains JSAny. It's a bit verbose, but it's the best I could come up with currently