### PR TITLE
Fix jsify on function

### DIFF
--- a/lib/src/rtc_peerconnection_impl.dart
+++ b/lib/src/rtc_peerconnection_impl.dart
@@ -314,7 +314,7 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
 
   @override
   Future<List<StatsReport>> getStats([MediaStreamTrack? track]) async {
-    var stats;
+    web.RTCStatsReport stats;
     if (track != null) {
       var jsTrack = (track as MediaStreamTrackWeb).jsTrack;
       stats = await _jsPc.getStats(jsTrack).toDart;
@@ -335,7 +335,7 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
             value.getProperty<JSString>('type'.toJS).toDart,
             value.getProperty<JSNumber>('timestamp'.toJS).toDartDouble,
             stats));
-      }.jsify()
+      }.toJS,
     ]);
     return report;
   }

--- a/lib/src/rtc_rtp_receiver_impl.dart
+++ b/lib/src/rtc_rtp_receiver_impl.dart
@@ -30,7 +30,7 @@ class RTCRtpReceiverWeb extends RTCRtpReceiver {
             value.getProperty<JSString>('type'.toJS).toDart,
             value.getProperty<JSNumber>('timestamp'.toJS).toDartDouble,
             stats));
-      }.jsify()
+      }.toJS,
     ]);
     return report;
   }

--- a/lib/src/rtc_rtp_sender_impl.dart
+++ b/lib/src/rtc_rtp_sender_impl.dart
@@ -98,7 +98,7 @@ class RTCRtpSenderWeb extends RTCRtpSender {
             value.getProperty<JSString>('type'.toJS).toDart,
             value.getProperty<JSNumber>('timestamp'.toJS).toDartDouble,
             stats));
-      }.jsify()
+      }.toJS,
     ]);
     return report;
   }


### PR DESCRIPTION
Fixes #60

As explained in the thread in #60, there are 2 issues.

First it says there is no `forEach` on `Instance of 'RtcStatsReport'`, which is weird, as that should exists, but `stats` is of type dynamic. This is fixed by setting the type of `stats` to `RTCStatsReport`.

When you do that you get `parameter 1 is not of type 'Function'.`. That's because `jsify` only works on primitives, so it converts the function to a generic object. By using `toJS` is converts the function to a `JSExportedDartFunction`.

Also fixes: https://github.com/flutter-webrtc/flutter-webrtc/issues/1781 and https://github.com/flutter-webrtc/flutter-webrtc/issues/1788