### PR TITLE
fix: parse `rid` and `ssrc` to proper types

### DIFF
--- a/lib/src/rtc_rtp_parameters_impl.dart
+++ b/lib/src/rtc_rtp_parameters_impl.dart
@@ -70,7 +70,7 @@ class RTCHeaderExtensionWeb {
 class RTCRtpEncodingWeb {
   static RTCRtpEncoding fromJsObject(web.RTCRtpEncodingParameters object) {
     return RTCRtpEncoding.fromMap({
-      'rid': object.getProperty<JSString?>('rid'.toJS)?.toDart,
+      'rid': object.getProperty<JSString?>('rid'.toJS).dartify(),
       'active': object.active,
       'maxBitrate': object.getProperty<JSNumber?>('maxBitrate'.toJS)?.toDartInt,
       'maxFramerate':
@@ -81,7 +81,7 @@ class RTCRtpEncodingWeb {
       'scaleResolutionDownBy': object
           .getProperty<JSNumber?>('scaleResolutionDownBy'.toJS)
           ?.toDartDouble,
-      'ssrc': object.getProperty<JSString?>('ssrc'.toJS)?.toDart
+      'ssrc': object.getProperty<JSNumber?>('ssrc'.toJS)?.toDartInt
     });
   }
 }


### PR DESCRIPTION
This caused an issue on Safari where tracks were not being published properly due to `rid` being `0` and getting parsed as an `int` rather than a `String`.

Tested on Safari, Chrome & Firefox.

```
[Error] TypeError: 0: type 'int' is not a subtype of type 'String?'
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 215:26  DartError
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 117:39             throw_
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 117:39             _asStringQ
package:dart_webrtc/src/rtc_rtp_parameters_impl.dart.js 121:2204              fromJsObject
package:dart_webrtc/src/rtc_rtp_parameters_impl.dart.js 51:74                 <fn>
dart-sdk/lib/_internal/js_dev_runtime/private/js_array.dart 219:8             <fn>
package:dart_webrtc/src/rtc_rtp_parameters_impl.dart.js 50:26                 encodingsFromJsObject
package:dart_webrtc/src/rtc_rtp_parameters_impl.dart.js 36:480                fromJsObject
package:livekit_client/src/widgets/video_track_renderer.dart.js 10532:72      LocalVideoTrackExt$124setDegradationPreference
package:livekit_client/src/widgets/video_track_renderer.dart.js 5128:79       <fn>
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 622:19           <fn>
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 647:23           <fn>
dart-sdk/lib/async/future_impl.dart 951:44                                    handleValueCallback
dart-sdk/lib/async/future_impl.dart 980:32                                    _propagateToListeners
dart-sdk/lib/async/future_impl.dart 723:5                                     <fn>
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 503:7            complete
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 570:12           _asyncReturn
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 622:19           <fn>
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 647:23           <fn>
dart-sdk/lib/async/future_impl.dart 951:44                                    handleValueCallback
dart-sdk/lib/async/future_impl.dart 980:32                                    _propagateToListeners
dart-sdk/lib/async/future_impl.dart 723:5                                     <fn>
dart-sdk/lib/async/future_impl.dart 807:7                                     <fn>
dart-sdk/lib/async/schedule_microtask.dart 40:11                              _microtaskLoop
dart-sdk/lib/async/schedule_microtask.dart 49:5                               _startMicrotaskLoop
dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 186:15           <fn>
```