### PR TITLE
fix: add OpenHarmony to isMobile detection for HarmonyOS WebView

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -10,7 +10,8 @@ bool get isMobile {
     'iPad',
     'iPod',
     'BlackBerry',
-    'Windows Phone'
+    'Windows Phone',
+    'OpenHarmony'
   ];
   return toMatch.indexWhere((device) => web.window.navigator.userAgent
           .contains(RegExp(device, caseSensitive: false))) !=


### PR DESCRIPTION
## Problem

When running a WebRTC application inside a HarmonyOS in-app WebView, the `facingMode` constraint is silently removed from `getUserMedia()` calls. This makes camera switching (front/back) impossible — it always defaults to the front camera.

## Root Cause

The `isMobile` getter in `lib/src/utils.dart` checks the User-Agent for known mobile platforms, but `OpenHarmony` is not in the list.

HarmonyOS in-app WebView UA (does NOT contain `Android`):
```
Mozilla/5.0 (Phone; OpenHarmony 6.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36
```

When `isMobile` returns `false`, `getUserMedia()` in `mediadevices_impl.dart` strips the `facingMode` constraint.

> Note: HarmonyOS standalone browser includes `Android` in its UA for web compatibility, so this issue only affects in-app WebView — the standard deployment model for Flutter Web apps on HarmonyOS.

## Fix

Add `OpenHarmony` to the `toMatch` list in `isMobile`. This is a minimal, low-risk change that extends platform coverage without affecting existing behavior.

Fixes #76