### PR TITLE
feat: remove package:js usage for full wasm compatibility

### DIFF
--- a/lib/src/e2ee.worker/e2ee.frame_cryptor.dart
+++ b/lib/src/e2ee.worker/e2ee.frame_cryptor.dart
@@ -4,8 +4,6 @@ import 'dart:js_interop_unsafe';
 import 'dart:math';
 import 'dart:typed_data';
 
-// ignore: deprecated_member_use
-import 'package:js/js.dart';
 import 'package:web/web.dart' as web;
 import 'e2ee.keyhandler.dart';
 import 'e2ee.logger.dart';
@@ -249,7 +247,7 @@ class FrameCryptor {
     }
     var transformer = web.TransformStream({
       'transform':
-          allowInterop(operation == 'encode' ? encodeFunction : decodeFunction)
+          (operation == 'encode' ? encodeFunction : decodeFunction).toJS
     }.jsify() as JSObject);
     try {
       readable

--- a/lib/src/e2ee.worker/e2ee.frame_cryptor.dart
+++ b/lib/src/e2ee.worker/e2ee.frame_cryptor.dart
@@ -246,8 +246,15 @@ class FrameCryptor {
       this.codec = codec;
     }
     var transformer = web.TransformStream({
-      'transform':
-          (operation == 'encode' ? encodeFunction : decodeFunction).toJS
+      'transform': (
+        JSObject frameObj,
+        web.TransformStreamDefaultController controller,
+      ) {
+        return (operation == 'encode' ? encodeFunction : decodeFunction)(
+          frameObj,
+          controller,
+        ).then((_) => null).toJS;
+      }.toJS,
     }.jsify() as JSObject);
     try {
       readable

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  js: ">0.6.0 <0.8.0"
   logging: ^1.1.0
   meta: ^1.8.0
   synchronized: ^3.0.0+3

--- a/web/p2p/p2p.dart
+++ b/web/p2p/p2p.dart
@@ -1,5 +1,4 @@
 import 'package:dart_webrtc/dart_webrtc.dart';
-import 'package:js/js.dart';
 import 'package:test/test.dart';
 import 'package:web/web.dart' as web;
 
@@ -30,17 +29,17 @@ void main() {
 
   remote?.append(remoteVideo.htmlElement);
 
-  signaling.onLocalStream = allowInterop((MediaStream stream) {
+  signaling.onLocalStream = (MediaStream stream) {
     localVideo.srcObject = stream;
-  });
+  };
 
-  signaling.onAddRemoteStream = allowInterop((MediaStream stream) {
+  signaling.onAddRemoteStream = (MediaStream stream) {
     remoteVideo.srcObject = stream;
-  });
+  };
 
   signaling.connect();
   signaling.onStateChange = (SignalingState state) {
-    web.document.querySelector('#output')?.text = state.toString();
+    web.document.querySelector('#output')?.textContent = state.toString();
     if (state == SignalingState.CallStateBye) {
       localVideo.srcObject = null;
       remoteVideo.srcObject = null;
@@ -78,16 +77,16 @@ void dartWebRTCTest(VideoElement video) async {
 
   var pc = RTCPeerConnection();
   print('connectionState: ${pc.connectionState}');
-  pc.onaddstream = allowInterop((MediaStreamEvent event) {});
+  pc.onaddstream = (MediaStreamEvent event) {};
   var stream = await PromiseToFuture<MediaStream>(
       navigator.mediaDevices.getDisplayMedia()
       /*.getUserMedia(MediaStreamConstraints(audio: true, video: true))*/);
   print('getDisplayMedia: stream.id => ${stream.id}');
-  stream.oninactive = allowInterop((Event event) {
+  stream.oninactive = (Event event) {
     print('oninactive: stream.id => ${event.target.id}');
     video.srcObject = null;
     video.remove();
-  });
+  };
   pc.addStream(stream);
   var rtcVideo = ConvertToRTCVideoElement(video);
   rtcVideo.srcObject = stream;


### PR DESCRIPTION
Plugin no longer depends on the deprecated `package:js` library