### PR TITLE
fix: casting fails as value is a dart value

### DIFF
--- a/lib/src/rtc_peerconnection_impl.dart
+++ b/lib/src/rtc_peerconnection_impl.dart
@@ -328,7 +328,7 @@ class RTCPeerConnectionWeb extends RTCPeerConnection {
         var map = value.dartify() as LinkedHashMap<Object?, Object?>;
         var stats = <String, dynamic>{};
         for (var entry in map.entries) {
-          stats[(entry.key as JSString).toDart] = entry.value;
+          stats[entry.key.toString()] = entry.value;
         }
         report.add(StatsReport(
             value.getProperty<JSString>('id'.toJS).toDart,

--- a/lib/src/rtc_rtp_receiver_impl.dart
+++ b/lib/src/rtc_rtp_receiver_impl.dart
@@ -23,7 +23,7 @@ class RTCRtpReceiverWeb extends RTCRtpReceiver {
         var map = value.dartify() as LinkedHashMap<Object?, Object?>;
         var stats = <String, dynamic>{};
         for (var entry in map.entries) {
-          stats[(entry.key as JSString).toDart] = entry.value;
+          stats[entry.key.toString()] = entry.value;
         }
         report.add(StatsReport(
             value.getProperty<JSString>('id'.toJS).toDart,

--- a/lib/src/rtc_rtp_sender_impl.dart
+++ b/lib/src/rtc_rtp_sender_impl.dart
@@ -91,7 +91,7 @@ class RTCRtpSenderWeb extends RTCRtpSender {
         var map = value.dartify() as LinkedHashMap<Object?, Object?>;
         var stats = <String, dynamic>{};
         for (var entry in map.entries) {
-          stats[(entry.key as JSString).toDart] = entry.value;
+          stats[entry.key.toString()] = entry.value;
         }
         report.add(StatsReport(
             value.getProperty<JSString>('id'.toJS).toDart,


### PR DESCRIPTION
`value.dartify()` deeply converts JS values to dart, hence we can just use native `.toString()` method